### PR TITLE
fix: improve NaiveDateTime.equal? implementation

### DIFF
--- a/lib/ecto/date_time_range/naive_date_time.ex
+++ b/lib/ecto/date_time_range/naive_date_time.ex
@@ -147,7 +147,7 @@ defmodule Ecto.DateTimeRange.NaiveDateTime do
         start_at: lower2,
         end_at: upper2
       }),
-      do: DateTime.compare(lower1, lower2) == :eq && DateTime.compare(upper1, upper2) == :eq
+      do: NaiveDateTime.compare(lower1, lower2) == :eq && NaiveDateTime.compare(upper1, upper2) == :eq
 
   def equal?(first, second), do: first == second
 

--- a/test/ecto/date_time_range/naive_date_time_test.exs
+++ b/test/ecto/date_time_range/naive_date_time_test.exs
@@ -145,4 +145,44 @@ defmodule Ecto.DateTimeRange.NaiveDateTimeTest do
     test "with time at end",
       do: refute(Ecto.DateTimeRange.NaiveDateTime.contains?(~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N, ~N[2022-01-01T02:00:00]))
   end
+
+  describe "equal?" do
+    import Ecto.DateTimeRange
+
+    test "with same start and end times",
+      do:
+        assert(
+          Ecto.DateTimeRange.NaiveDateTime.equal?(
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N,
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N
+          )
+        )
+
+    test "with different start times",
+      do:
+        refute(
+          Ecto.DateTimeRange.NaiveDateTime.equal?(
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N,
+            ~t[2022-01-01T01:00:01..2022-01-01T02:00:00]N
+          )
+        )
+
+    test "with different end times",
+      do:
+        refute(
+          Ecto.DateTimeRange.NaiveDateTime.equal?(
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N,
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:01]N
+          )
+        )
+
+    test "with different start and end times",
+      do:
+        refute(
+          Ecto.DateTimeRange.NaiveDateTime.equal?(
+            ~t[2022-01-01T01:00:00..2022-01-01T02:00:00]N,
+            ~t[2022-01-01T01:00:01..2022-01-01T02:00:01]N
+          )
+        )
+  end
 end


### PR DESCRIPTION
The equal?/2 function was using DateTime instead of NativeDateTime to perform equality check.